### PR TITLE
Revert changes on server certs

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -58,10 +58,8 @@ http {
     listen ${port.port} http2 backlog=16384;
   % elif port.proto == 'ssl':
     listen ${port.port} ssl http2 backlog=16384;
-    % if tls_mutual_auth:
-      proxy_ssl_certificate /etc/nginx/ssl/backend.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/backend.key;
-    % endif
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
   % endif
 % endfor
 


### PR DESCRIPTION
Sorry for the error in previous PR https://github.com/cloudendpoints/endpoints-tools/pull/4. This reverts changes made to line 61-62 in `nginx-auto.conf.template`.