### PR TITLE
Fixed IP address subnet mask ranges

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -48,8 +48,8 @@ http {
 % endif
 % endfor
 
-  set_real_ip_from  0.0.0.0/1;
-  set_real_ip_from  0::/1;
+  set_real_ip_from  0.0.0.0/0;
+  set_real_ip_from  0::/0;
   real_ip_header    X-Forwarded-For;
   real_ip_recursive on;
 


### PR DESCRIPTION
0.0.0.0/1 only support 0.0.0.0 to 127.255.25.255

