### PR TITLE
Add options to allow more characters in headers

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -78,6 +78,14 @@ http {
     }
 % endif
 
+% if underscores_in_headers:
+    underscores_in_headers on;
+% endif
+
+% if allow_invalid_headers:
+    ignore_invalid_headers off;
+% endif
+
 % for i, location in enumerate(ingress.locations):
     location ${location.path} {
       # Begin Endpoints v2 Support

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -123,7 +123,9 @@ def write_template(ingress, nginx_conf, args):
             access_log=args.access_log,
             healthz=args.healthz,
             xff_trusted_proxies=args.xff_trusted_proxies,
-            tls_mutual_auth=args.tls_mutual_auth)
+            tls_mutual_auth=args.tls_mutual_auth,
+            underscores_in_headers=args.underscores_in_headers,
+            allow_invalid_headers=args.allow_invalid_headers)
 
     # Save nginx conf
     try:
@@ -466,6 +468,17 @@ config file.'''.format(
     parser.add_argument('--check_metadata', action='store_true',
         help='''Enable fetching access token, service name, service config ID
         and rollout strategy from the metadata service''')
+
+    parser.add_argument('--underscores_in_headers', action='store_true',
+        help='''Allow headers contain underscores to pass through by setting
+        "underscores_in_headers on;" directive.
+        ''')
+
+    parser.add_argument('--allow_invalid_headers', action='store_true',
+        help='''Allow "invalid" headers by adding "ignore_invalid_headers off;"
+        directive. This is required to support all legal characters specified
+        in RFC 7230.
+        ''')
 
     # Specify a custom service.json path.
     # If this is specified, service json will not be fetched.


### PR DESCRIPTION
This adds arguments to `start_esp` script:
- `--underscores_in_headers`: Allows headers with underscores to be passed ([nginx doc](http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers)).
- `--allow_invalid_headers `: Allows all "invalid" headers ([nginx doc](http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers)). This is necessary to allow some legal header characters specified in [RFC 7230](https://tools.ietf.org/html/rfc7230#page-84).