### PR TITLE
Added command line option --transcoding_always_print_primitive_fields (#227)

### DIFF
--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -31,5 +31,6 @@ service_management_config {
 % endif
 experimental {
   disable_log_status: true
+  always_print_primitive_fields: ${always_print_primitive_fields}
 }
 rollout_strategy: "${rollout_strategy}"

--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -31,6 +31,8 @@ service_management_config {
 % endif
 experimental {
   disable_log_status: true
-  always_print_primitive_fields: ${always_print_primitive_fields}
+% if always_print_primitive_fields:
+  always_print_primitive_fields: true
+% endif
 }
 rollout_strategy: "${rollout_strategy}"

--- a/start_esp/server_config.pb.txt
+++ b/start_esp/server_config.pb.txt
@@ -1,3 +1,4 @@
 experimental {
   disable_log_status: true
+  always_print_primitive_fields: false
 }

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -148,7 +148,8 @@ def write_server_config_templage(server_config, args):
              service_configs=args.service_configs,
              management=args.management,
              rollout_id=args.rollout_id,
-             rollout_strategy=args.rollout_strategy)
+             rollout_strategy=args.rollout_strategy,
+             always_print_primitive_fields=args.transcoding_always_print_primitive_fields)
 
     # Save nginx conf
     try:
@@ -531,6 +532,11 @@ config file.'''.format(
     # PID file location.
     parser.add_argument('--pid_file',
         default=DEFAULT_PID_FILE,
+        help=argparse.SUPPRESS)
+
+    # always_print_primitive_fields.
+    parser.add_argument('--transcoding_always_print_primitive_fields',
+        default='false',
         help=argparse.SUPPRESS)
 
     return parser

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -536,7 +536,7 @@ config file.'''.format(
 
     # always_print_primitive_fields.
     parser.add_argument('--transcoding_always_print_primitive_fields',
-        default='false',
+        action='store_true',
         help=argparse.SUPPRESS)
 
     return parser


### PR DESCRIPTION
@lizan Command-line option as discussed for enabling the always_print_primitive_fields experimental feature 