### PR TITLE
scale nginx workers with number of cores

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -20,7 +20,7 @@ user nginx nginx;
 pid ${pid_file};
 
 # Worker/connection processing limits
-worker_processes 1;
+worker_processes auto;
 worker_rlimit_nofile 10240;
 events { worker_connections 10240; }
 


### PR DESCRIPTION
Nginx doesn't use worker threads, meaning with the current configuration, the esp can only ever take advantage of one cpu core, which can become a bottleneck especially if TLS in involved. The nginx docs http://nginx.org/en/docs/ngx_core_module.html#worker_processes even recommend auto as a good place to start.

```
$ ps axH |grep nginx
 1926 ?        Ss     0:00 nginx: master process nginx -p /usr -c /etc/nginx/endpoints/nginx.conf
 1949 ?        S     66:42 nginx: worker process
```

This could have implications where docker is involved, so maybe making it configurable with a flag is ideal. But I still think auto is a better default.