### PR TITLE
Fix a bug in nginx-auto.conf.template

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -140,8 +140,8 @@ http {
       proxy_send_timeout 86400s;
       proxy_read_timeout 86400s;
 % endif
-% endfor
     }
+% endfor
 
     include /var/lib/nginx/extra/*.conf;
   }


### PR DESCRIPTION
The closing brace of a for loop in nginx-auto.conf.template was placed at a wrong location, which will lead to syntax errors when the loop is executed more than 1 iterations.