### PR TITLE
Fix typo in the default CORS headers.

### DIFF
--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -645,7 +645,7 @@ config file.'''.format(
         methods.
         ''')
     parser.add_argument('--cors_allow_headers',
-        default='DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Rang,Authorization',
+        default='DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization',
         help='''
         Only works when --cors_preset is in use. Configures the CORS header
         Access-Control-Allow-Headers. Defaults to allow common HTTP


### PR DESCRIPTION
The standard HTTP header is called "Range"[1].

[1] https://tools.ietf.org/html/rfc7233