### PR TITLE
Add cors_allow_origin_regex and cors_allow_credentials option (#58)

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -118,9 +118,11 @@ http {
   % if cors_allow_origin_regex != '':
     if ($http_origin ~* (${cors_allow_origin_regex})) {
         set $cors "true";
+        set $allow_origin $http_origin;
     }
   % else:
     set $cors "true";
+    set $allow_origin "${cors_allow_origin}";
   % endif
 
     if ($request_method = 'OPTIONS') {
@@ -129,11 +131,7 @@ http {
 
     if ($cors = "trueoptions") {
         add_header 'Access-Control-Max-Age' 1728000;
-      % if cors_allow_origin_regex != '':
-        add_header 'Access-Control-Allow-Origin' "$http_origin";
-      % else:
-        add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}';
-      % endif
+        add_header 'Access-Control-Allow-Origin' "$allow_origin";
         add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}';
         add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}';
       % if cors_allow_credentials and cors_allow_origin != '*':
@@ -145,11 +143,7 @@ http {
     }
 
     if ($cors = "true") {
-      % if cors_allow_origin_regex != '':
-        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-      % else:
-        add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}' always;
-      % endif
+        add_header 'Access-Control-Allow-Origin' "$allow_origin";
         add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
         add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
         add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;

--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -113,16 +113,16 @@ http {
       proxy_set_header Connection $connection_upgrade;
 % endif
 
-% if cors_preset == 'basic':
-    # Begin basic CORS preset
-  % if cors_allow_origin_regex != '':
+% if cors_preset:
+    # Begin CORS settings
+  % if cors_preset == 'basic':
+    set $cors "true";
+    set $allow_origin "${cors_allow_origin}";
+  % elif cors_preset == 'cors_with_regex':
     if ($http_origin ~* (${cors_allow_origin_regex})) {
         set $cors "true";
         set $allow_origin $http_origin;
     }
-  % else:
-    set $cors "true";
-    set $allow_origin "${cors_allow_origin}";
   % endif
 
     if ($request_method = 'OPTIONS') {
@@ -134,7 +134,7 @@ http {
         add_header 'Access-Control-Allow-Origin' "$allow_origin";
         add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}';
         add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}';
-      % if cors_allow_credentials and cors_allow_origin != '*':
+      % if cors_allow_credentials:
         add_header 'Access-Control-Allow-Credentials' 'true';
       % endif
         add_header 'Content-Type' 'text/plain; charset=utf-8';
@@ -147,11 +147,11 @@ http {
         add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
         add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
         add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;
-      % if cors_allow_credentials and cors_allow_origin != '*':
+      % if cors_allow_credentials:
         add_header 'Access-Control-Allow-Credentials' 'true' always;
       % endif
     }
-    # End basic CORS preset
+    # End CORS settings
 % endif
 
 % if location.proto == 'grpc':

--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -120,6 +120,9 @@ http {
       add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}';
       add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}';
       add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}';
+      % if cors_allow_credentials and cors_allow_origin != '*':
+        add_header 'Access-Control-Allow-Credentials' 'true';
+      % endif
       add_header 'Content-Type' 'text/plain; charset=utf-8';
       add_header 'Content-Length' 0;
       return 204;
@@ -128,6 +131,9 @@ http {
     add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
     add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
     add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;
+    % if cors_allow_credentials and cors_allow_origin != '*':
+      add_header 'Access-Control-Allow-Credentials' 'true' always;
+    % endif
     # End basic CORS preset
 % endif
 
@@ -186,4 +192,3 @@ http {
     }
   }
 }
-

--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -115,25 +115,48 @@ http {
 
 % if cors_preset == 'basic':
     # Begin basic CORS preset
-    if (${'$'}request_method = 'OPTIONS') {
-      add_header 'Access-Control-Max-Age' 1728000;
-      add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}';
-      add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}';
-      add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}';
+  % if cors_allow_origin_regex != '':
+    if ($http_origin ~* (${cors_allow_origin_regex})) {
+        set $cors "true";
+    }
+  % else:
+    set $cors "true";
+  % endif
+
+    if ($request_method = 'OPTIONS') {
+        set $cors "${'$'}{cors}options";
+    }
+
+    if ($cors = "trueoptions") {
+        add_header 'Access-Control-Max-Age' 1728000;
+      % if cors_allow_origin_regex != '':
+        add_header 'Access-Control-Allow-Origin' "$http_origin";
+      % else:
+        add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}';
+      % endif
+        add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}';
+        add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}';
       % if cors_allow_credentials and cors_allow_origin != '*':
         add_header 'Access-Control-Allow-Credentials' 'true';
       % endif
-      add_header 'Content-Type' 'text/plain; charset=utf-8';
-      add_header 'Content-Length' 0;
-      return 204;
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
     }
-    add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}' always;
-    add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
-    add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
-    add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;
-    % if cors_allow_credentials and cors_allow_origin != '*':
-      add_header 'Access-Control-Allow-Credentials' 'true' always;
-    % endif
+
+    if ($cors = "true") {
+      % if cors_allow_origin_regex != '':
+        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
+      % else:
+        add_header 'Access-Control-Allow-Origin' '${cors_allow_origin}' always;
+      % endif
+        add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
+        add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
+        add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;
+      % if cors_allow_credentials and cors_allow_origin != '*':
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+      % endif
+    }
     # End basic CORS preset
 % endif
 

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -636,6 +636,10 @@ config file.'''.format(
           Responds to preflight OPTIONS requests with an empty 204, and the
           results of preflight are allowed to be cached for up to 20 days
           (1728000 seconds). See descriptions for args --cors_allow_origin,
+          --cors_allow_methods, --cors_allow_headers, --cors_expose_headers,
+          --cors_allow_credentials for more granular configurations.
+        - cors_with_regex - Same as basic preset, except that specifying
+          allowed origins in regular expression. See descriptions for args
           --cors_allow_origin_regex, --cors_allow_methods,
           --cors_allow_headers, --cors_expose_headers, --cors_allow_credentials
           for more granular configurations.
@@ -643,17 +647,15 @@ config file.'''.format(
     parser.add_argument('--cors_allow_origin',
         default='*',
         help='''
-        Only works when --cors_preset is in use. Configures the CORS header
-        Access-Control-Allow-Origin. Defaults to "*" which allows all
-        origins. If --cors_allow_origin_regex is set, then this option is
-        ignored.
+        Only works when --cors_preset is 'basic'. Configures the CORS header
+        Access-Control-Allow-Origin. Defaults to "*" which allows all origins.
         ''')
     parser.add_argument('--cors_allow_origin_regex',
         default='',
         help='''
-        Only works when --cors_preset is in use. Configures the whitelists of
-        CORS header Access-Control-Allow-Origin with regular expression. If you
-        specify this option, then --cors_allow_origin option is ignored.
+        Only works when --cors_preset is 'cors_with_regex'. Configures the
+        whitelists of CORS header Access-Control-Allow-Origin with regular
+        expression.
         ''')
     parser.add_argument('--cors_allow_methods',
         default='GET, POST, PUT, PATCH, DELETE, OPTIONS',
@@ -671,9 +673,8 @@ config file.'''.format(
         ''')
     parser.add_argument('--cors_allow_credentials', action='store_true',
         help='''
-        Only works when --cors_preset is in use and --cors_allow_origin is not
-        "*". Enable the CORS header Access-Control-Allow-Credentials. By
-        default, this header is disabled.
+        Only works when --cors_preset is in use. Enable the CORS header
+        Access-Control-Allow-Credentials. By default, this header is disabled.
         ''')
     parser.add_argument('--cors_expose_headers',
         default='Content-Length,Content-Range',

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -137,6 +137,7 @@ def write_template(ingress, nginx_conf, args):
             cors_allow_origin=args.cors_allow_origin,
             cors_allow_methods=args.cors_allow_methods,
             cors_allow_headers=args.cors_allow_headers,
+            cors_allow_credentials=args.cors_allow_credentials,
             cors_expose_headers=args.cors_expose_headers,
             google_cloud_platform=(args.non_gcp==False))
 
@@ -634,8 +635,8 @@ config file.'''.format(
           Responds to preflight OPTIONS requests with an empty 204, and the
           results of preflight are allowed to be cached for up to 20 days
           (1728000 seconds). See descriptions for args --cors_allow_origin,
-          --cors_allow_methods, --cors_allow_headers, --cors_expose_headers
-          for more granular configurations.
+          --cors_allow_methods, --cors_allow_headers, --cors_expose_headers,
+          --cors_allow_credentials for more granular configurations.
         ''')
     parser.add_argument('--cors_allow_origin',
         default='*',
@@ -657,6 +658,12 @@ config file.'''.format(
         Only works when --cors_preset is in use. Configures the CORS header
         Access-Control-Allow-Headers. Defaults to allow common HTTP
         headers.
+        ''')
+    parser.add_argument('--cors_allow_credentials', action='store_true',
+        help='''
+        Only works when --cors_preset is in use and --cors_allow_origin is not
+        "*". Enable the CORS header Access-Control-Allow-Credentials. By
+        default, this header is disabled.
         ''')
     parser.add_argument('--cors_expose_headers',
         default='Content-Length,Content-Range',

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -135,6 +135,7 @@ def write_template(ingress, nginx_conf, args):
             worker_processes=args.worker_processes,
             cors_preset=args.cors_preset,
             cors_allow_origin=args.cors_allow_origin,
+            cors_allow_origin_regex=args.cors_allow_origin_regex,
             cors_allow_methods=args.cors_allow_methods,
             cors_allow_headers=args.cors_allow_headers,
             cors_allow_credentials=args.cors_allow_credentials,
@@ -635,15 +636,24 @@ config file.'''.format(
           Responds to preflight OPTIONS requests with an empty 204, and the
           results of preflight are allowed to be cached for up to 20 days
           (1728000 seconds). See descriptions for args --cors_allow_origin,
-          --cors_allow_methods, --cors_allow_headers, --cors_expose_headers,
-          --cors_allow_credentials for more granular configurations.
+          --cors_allow_origin_regex, --cors_allow_methods,
+          --cors_allow_headers, --cors_expose_headers, --cors_allow_credentials
+          for more granular configurations.
         ''')
     parser.add_argument('--cors_allow_origin',
         default='*',
         help='''
         Only works when --cors_preset is in use. Configures the CORS header
         Access-Control-Allow-Origin. Defaults to "*" which allows all
-        origins.
+        origins. If --cors_allow_origin_regex is set, then this option is
+        ignored.
+        ''')
+    parser.add_argument('--cors_allow_origin_regex',
+        default='',
+        help='''
+        Only works when --cors_preset is in use. Configures the whitelists of
+        CORS header Access-Control-Allow-Origin with regular expression. If you
+        specify this option, then --cors_allow_origin option is ignored.
         ''')
     parser.add_argument('--cors_allow_methods',
         default='GET, POST, PUT, PATCH, DELETE, OPTIONS',


### PR DESCRIPTION
Setting multiple origins on 'Access-Control-Allow-Origin' header causes following Google Chrome error:

```
Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost:3000 http://localhost:3001', but only one is allowed. Origin 'http://localhost:3000' is therefore not allowed access.
```

This pull request fixes this issue by returning only one origin by using whitelist.

Reference: https://gist.github.com/alexjs/4165271

Also, added 'Access-Control-Allow-Credentials' header.