### PR TITLE
Add the parameter ssl_protocols to specify the SSL protocols

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -64,7 +64,22 @@ http {
   server {
     server_name ${ingress.host};
 
-    ssl_protocols ${ssl_protocols};
+% if ssl_protocols:
+  <%
+    ssl_protocol_list = ""
+  %>
+  % for idx, val in enumerate(ssl_protocols):
+    <%
+      ssl_protocol_list += val
+    %>
+    % if idx < len(ssl_protocols)-1:
+      <%
+        ssl_protocol_list += " "
+      %>
+    % endif
+  % endfor
+    ssl_protocols ${ssl_protocol_list};
+% endif
 
 % for port in ingress.ports:
   % if port.proto == 'http':

--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -64,6 +64,8 @@ http {
   server {
     server_name ${ingress.host};
 
+    ssl_protocols ${ssl_protocols};
+
 % for port in ingress.ports:
   % if port.proto == 'http':
     listen ${port.port} backlog=16384;

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -701,7 +701,7 @@ config file.'''.format(
         default=None, action='append', help='''
         Enable the specified SSL protocols. Please refer to
         https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols.
-        The "ssl_protocols" argument can be repeat multiple times to specify multiple
+        The "ssl_protocols" argument can be repeated multiple times to specify multiple
         SSL protocols (e.g., --ssl_protocols=TLSv1.1 --ssl_protocols=TLSv1.2).
         ''')
 

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -699,7 +699,7 @@ config file.'''.format(
         ''')
     parser.add_argument('--ssl_protocols',
         default=None, action='append', help='''
-        Enable the specified SSL protocols (space separated). Please refer to
+        Enable the specified SSL protocols. Please refer to
         https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols.
         The "ssl_protocols" argument can be repeat multiple times to specify multiple
         SSL protocols (e.g., --ssl_protocols=TLSv1.1 --ssl_protocols=TLSv1.2).

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -88,9 +88,6 @@ DEFAULT_PID_FILE = "/var/run/nginx.pid"
 # Default nginx worker_processes
 DEFAULT_WORKER_PROCESSES = "1"
 
-# Default SSL protocols
-DEFAULT_SSL_PROTOCOLS = "TLSv1 TLSv1.1 TLSv1.2"
-
 # Google default application credentials environment variable
 GOOGLE_CREDS_KEY = "GOOGLE_APPLICATION_CREDENTIALS"
 
@@ -701,12 +698,12 @@ config file.'''.format(
         this flag value.
         ''')
     parser.add_argument('--ssl_protocols',
-        default=DEFAULT_SSL_PROTOCOLS,
-        help='''
+        default=None, action='append', help='''
         Enable the specified SSL protocols (space separated). Please refer to
         https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols.
-        Default value: {ssl_protocols}. 
-        '''.format(ssl_protocols=DEFAULT_SSL_PROTOCOLS))
+        The "ssl_protocols" argument can be repeat multiple times to specify multiple
+        SSL protocols (e.g., --ssl_protocols=TLSv1.1 --ssl_protocols=TLSv1.2).
+        ''')
 
     return parser
 

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -88,6 +88,9 @@ DEFAULT_PID_FILE = "/var/run/nginx.pid"
 # Default nginx worker_processes
 DEFAULT_WORKER_PROCESSES = "1"
 
+# Default SSL protocols
+DEFAULT_SSL_PROTOCOLS = "TLSv1 TLSv1.1 TLSv1.2"
+
 # Google default application credentials environment variable
 GOOGLE_CREDS_KEY = "GOOGLE_APPLICATION_CREDENTIALS"
 
@@ -140,6 +143,7 @@ def write_template(ingress, nginx_conf, args):
             cors_allow_headers=args.cors_allow_headers,
             cors_allow_credentials=args.cors_allow_credentials,
             cors_expose_headers=args.cors_expose_headers,
+            ssl_protocols=args.ssl_protocols,
             google_cloud_platform=(args.non_gcp==False))
 
     # Save nginx conf
@@ -696,6 +700,13 @@ config file.'''.format(
         still be enabled from request HTTP headers with trace context regardless
         this flag value.
         ''')
+    parser.add_argument('--ssl_protocols',
+        default=DEFAULT_SSL_PROTOCOLS,
+        help='''
+        Enable the specified SSL protocols (space separated). Please refer to
+        https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols.
+        Default value: {ssl_protocols}. 
+        '''.format(ssl_protocols=DEFAULT_SSL_PROTOCOLS))
 
     return parser
 


### PR DESCRIPTION
Add the parameter ssl_protocols to specify the SSL protocols. The "ssl_protocols" input parameter can be repeated multiple times to specify multiple SSL protocols,  e.g., --ssl_protocols=TLSv1.1 --ssl_protocols=TLSv1.2, which only allows TLS 1.1 and 1.2 while disabling TLS 1.0.
Refer to https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols.