### PR TITLE
 add service_control_url_override option

### DIFF
--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -29,9 +29,9 @@ service_management_config {
   url: "${management}"
 }
 % endif
-% if service_control_override:
+% if service_control_url_override:
 service_control_config {
-  url_override: "${service_control_override}"
+  url_override: "${service_control_url_override}"
 }
 % endif
 % if client_ip_header:

--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -29,6 +29,11 @@ service_management_config {
   url: "${management}"
 }
 % endif
+% if service_control_override:
+service_control_config {
+  url_override: "${service_control_override}"
+}
+% endif
 % if client_ip_header:
 client_ip_extraction_config {
   client_ip_header: "${client_ip_header}"

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -162,6 +162,7 @@ def write_server_config_template(server_config, args):
     conf = template.render(
              service_configs=args.service_configs,
              management=args.management,
+             service_control_override=args.service_control_override,
              rollout_id=args.rollout_id,
              rollout_strategy=args.rollout_strategy,
              always_print_primitive_fields=args.transcoding_always_print_primitive_fields,
@@ -568,6 +569,11 @@ config file.'''.format(
     # Customize management service url prefix.
     parser.add_argument('-g', '--management',
         default=MANAGEMENT_ADDRESS,
+        help=argparse.SUPPRESS)
+
+    # Customize servicecontrol url prefix.
+    parser.add_argument('--service_control_override',
+        default=None,
         help=argparse.SUPPRESS)
 
     # Fetched service config and generated nginx config are placed

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -162,7 +162,7 @@ def write_server_config_template(server_config, args):
     conf = template.render(
              service_configs=args.service_configs,
              management=args.management,
-             service_control_override=args.service_control_override,
+             service_control_url_override=args.service_control_url_override,
              rollout_id=args.rollout_id,
              rollout_strategy=args.rollout_strategy,
              always_print_primitive_fields=args.transcoding_always_print_primitive_fields,
@@ -572,7 +572,7 @@ config file.'''.format(
         help=argparse.SUPPRESS)
 
     # Customize servicecontrol url prefix.
-    parser.add_argument('--service_control_override',
+    parser.add_argument('--service_control_url_override',
         default=None,
         help=argparse.SUPPRESS)
 


### PR DESCRIPTION
Current use case would be to set this to a value like `http://servicecontrol.googleapis.com:443` to support TLS origination from an Envoy proxy within an istio deployment

```
esp (plain text) -> envoy (encrypted) -> servicecontrol
```

See [cloudendpoints/esp/src/api_manager/service_control/url.cc](https://github.com/cloudendpoints/esp/blob/1775d95306a21ae43d71ec20f633600074ab4119/src/api_manager/service_control/url.cc#L39-L46) and [cloudendpoints/esp/src/api_manager/proto/server_config.proto](https://github.com/cloudendpoints/esp/blob/74fefb91bee99282076c03ed6f122e7894a988cb/src/api_manager/proto/server_config.proto#L68-L70)