### PR TITLE
add cloud_trace_url_override option

### DIFF
--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -41,11 +41,16 @@ experimental {
   always_print_primitive_fields: true
 % endif
 }
-% if disable_cloud_trace_auto_sampling:
+% if disable_cloud_trace_auto_sampling or cloud_trace_url_override:
 cloud_tracing_config {
+  % if cloud_trace_url_override:
+  url_override: "${cloud_trace_url_override}"
+  % endif
+  % if disable_cloud_trace_auto_sampling:
   samling_config {
     minimum_qps: 0
   }
+  % endif
 }
 % endif
 % if rewrite_rules:

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -168,7 +168,8 @@ def write_server_config_template(server_config, args):
              client_ip_header=args.client_ip_header,
              client_ip_position=args.client_ip_position,
              rewrite_rules=args.rewrite,
-             disable_cloud_trace_auto_sampling=args.disable_cloud_trace_auto_sampling)
+             disable_cloud_trace_auto_sampling=args.disable_cloud_trace_auto_sampling,
+             cloud_trace_url_override=args.cloud_trace_url_override)
 
     # Save nginx conf
     try:
@@ -696,6 +697,11 @@ config file.'''.format(
         still be enabled from request HTTP headers with trace context regardless
         this flag value.
         ''')
+
+    # Customize cloudtrace service url prefix.
+    parser.add_argument('--cloud_trace_url_override',
+        default=None,
+        help=argparse.SUPPRESS)
 
     return parser
 


### PR DESCRIPTION
Current use case would be to set this to a value like `http://cloudtrace.googleapis.com:443` to support TLS origination from an Envoy proxy within an istio deployment

```
esp (plain text) -> envoy (encrypted) -> cloudtrace
```

See [cloudendpoints/esp/src/api_manager/context/global_context.cc](https://github.com/cloudendpoints/esp/blob/1775d95306a21ae43d71ec20f633600074ab4119/src/api_manager/context/global_context.cc#L97-L101) and [cloudendpoints/esp/src/api_manager/proto/server_config.proto](https://github.com/cloudendpoints/esp/blob/74fefb91bee99282076c03ed6f122e7894a988cb/src/api_manager/proto/server_config.proto#L148-L150)